### PR TITLE
Add GitHub Actions CI + Pages deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit / component tests
+        run: npm test
+
+      - name: Production build
+        run: npm run build

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,74 @@
+# Build the Vite app and publish to GitHub Pages.
+#
+# One-time repo setup (required before the first successful deploy):
+#   1. Settings → Pages → Build and deployment → Source: "GitHub Actions"
+#   2. (Optional) Settings → Pages → Custom domain: madneal.com
+#      Keep DNS CNAME / A records pointed at GitHub; enforce HTTPS.
+#   3. Settings → Actions → General → Workflow permissions:
+#      allow "Read and write permissions" (or rely on the permissions: block below).
+#
+# Site URL after deploy:
+#   https://madneal.com/subway-shanghai/
+#   https://madneal.github.io/subway-shanghai/
+
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  # Allow manual redeploy from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One active deploy at a time; do not cancel an in-flight production deploy
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+        # vite.config.js base is /subway-shanghai/ — required for project Pages path
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Interactive Shanghai metro map. Originally rebuilt on Create React App; now runs on **Vite + React 18**.
 
-Live site: https://neal1991.github.io/subway-shanghai/
+Live site: https://madneal.com/subway-shanghai/
 
 ## Component structure
 
@@ -24,8 +24,31 @@ npm install
 npm start          # Vite dev server (http://localhost:5173/subway-shanghai/)
 npm run build      # production build → dist/
 npm run preview    # serve the production build locally
-npm run deploy     # build + publish dist/ to gh-pages
+npm run deploy     # optional local deploy via gh-pages branch (prefer Actions)
 ```
+
+## Deploy with GitHub Actions
+
+Pushing to `master` runs two workflows:
+
+| Workflow | File | When | What |
+|----------|------|------|------|
+| **CI** | `.github/workflows/ci.yml` | PR + push to `master` | `npm test` + `npm run build` |
+| **Deploy GitHub Pages** | `.github/workflows/deploy-pages.yml` | push to `master` / manual | test → build → publish Pages |
+
+### One-time GitHub settings
+
+1. Open **Settings → Pages**.
+2. Under **Build and deployment → Source**, choose **GitHub Actions** (not “Deploy from a branch”).
+3. If you use a custom domain (`madneal.com`):
+   - Set **Custom domain** to `madneal.com`
+   - Keep DNS pointing at GitHub and enable **Enforce HTTPS**
+4. Under **Settings → Actions → General → Workflow permissions**, allow the default workflow `GITHUB_TOKEN` to deploy Pages (the workflow already sets `pages: write` + `id-token: write`).
+
+### First deploy / redeploy
+
+- Merge to `master`, or open **Actions → Deploy GitHub Pages → Run workflow**.
+- After it is green, open https://madneal.com/subway-shanghai/ and confirm the HTML loads `/subway-shanghai/assets/index-*.js` (Vite), not `/static/js/main.*.chunk.js` (old CRA).
 
 ## Test
 
@@ -47,4 +70,4 @@ npx playwright install chromium
 
 ## LICENSE
 
-[MIT](https://github.com/neal1991/subway-shanghai/blob/master/LICENSE.md)
+[MIT](https://github.com/madneal/subway-shanghai/blob/master/LICENSE.md)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subway-shanghai",
-  "homepage": "https://neal1991.github.io/subway-shanghai",
+  "homepage": "https://madneal.com/subway-shanghai",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
       include: '**/*.{jsx,js}',
     }),
   ],
-  // GitHub Pages project site: https://neal1991.github.io/subway-shanghai/
+  // Project Pages path (also used under custom domain madneal.com/subway-shanghai/)
   base: '/subway-shanghai/',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary

Adds GitHub Actions so the Vite site deploys automatically instead of relying on a local `npm run deploy` / stale `gh-pages` branch.

- **CI** (`.github/workflows/ci.yml`): on PR/push to `master` → `npm ci` → `npm test` → `npm run build`
- **Deploy** (`.github/workflows/deploy-pages.yml`): on push to `master` (or manual) → test → build → `actions/upload-pages-artifact` → `actions/deploy-pages`

## One-time settings (required)

Before the deploy job can publish:

1. **Settings → Pages → Build and deployment → Source** → **GitHub Actions**
2. Keep custom domain / HTTPS as you already use for https://madneal.com/subway-shanghai/
3. Confirm workflow can write Pages (`pages: write` is set in the workflow)

## After merge

1. Watch **Actions → Deploy GitHub Pages** go green
2. Hard-refresh https://madneal.com/subway-shanghai/
3. View source: should see Vite `assets/index-*.js`, not CRA `static/js/*.chunk.js`