### PR TITLE
Update README for Vite + GitHub Actions deploy

### DIFF
--- a/README-CHINESE.md
+++ b/README-CHINESE.md
@@ -1,22 +1,90 @@
 # :train2::train2::train2: 上海地铁线路图
 
-之前的版本主要是基于原生 js 写的，的确随着代码量的增加，代码显得愈发的混乱，因此新的版本基于 create react app 实现了一次完整的重构。
+交互式上海地铁线路图。
+
+**技术栈：** Vite 6 + React 18  
+**线上地址：** https://madneal.com/subway-shanghai/  
+**English:** [README.md](./README.md)
+
+早期版本用原生 JS，后用 Create React App 重构，现已迁移到 Vite。
 
 ## 组件结构
 
-将整个地图理解成一个 Map 组件，再将其分为 4 个小组件：
+将整个地图看作一个 `Map` 组件，再拆成 4 个子组件：
 
 ![map.png](http://ozfo4jjxb.bkt.clouddn.com/map.png)
 
-* Label: 地图上的文本信息，包括地铁站名，线路名称
-* Station: 地铁站点，包括普通站点和中转站点
-* Line： 地铁线路
-* InfoCard: 状态最复杂的一个组件，主要包含时刻表信息、卫生间位置信息、出入口信息、无障碍电梯信息
+| 组件 | 作用 |
+|------|------|
+| **Label** | 站名、线路名等文字 |
+| **Station** | 普通站与换乘站 |
+| **Line** | 地铁线路路径 |
+| **InfoCard** | 时刻表、卫生间、出入口、无障碍电梯 |
+
+## 本地开发
+
+```bash
+npm install
+npm start          # http://localhost:5173/subway-shanghai/
+npm run build      # 产物在 dist/
+npm run preview    # 本地预览生产构建
+```
+
+站点 base 为 `/subway-shanghai/`（GitHub Pages 项目路径），本地开发也使用同一路径。
+
+## 测试
+
+| 命令 | 说明 |
+|------|------|
+| `npm test` | 单元 + 组件测试（Vitest + Testing Library） |
+| `npm run test:watch` | 监听模式 |
+| `npm run test:coverage` | 覆盖率报告 → `coverage/` |
+| `npm run test:e2e` | Playwright，对生产构建做冒烟测试 |
+| `npm run test:all` | 单测 → 构建 → e2e |
+
+首次跑 e2e 需安装浏览器：
+
+```bash
+npx playwright install chromium
+```
+
+覆盖范围概览：
+
+- **单元** — 时刻表加减时间、周末末班车延长等
+- **数据** — 线路颜色、站点/换乘/标签与 stationInfo 结构
+- **组件** — 地图渲染、点击站点打开信息卡、关闭按钮
+- **E2E** — 真实 Chromium 访问 `vite preview` 产物
+
+## 部署（GitHub Actions）
+
+生产环境由 **`master`** 上的 GitHub Actions 自动部署（Pages 源为 **GitHub Actions**）。
+
+| 工作流 | 文件 | 触发时机 | 做什么 |
+|--------|------|----------|--------|
+| **CI** | [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) | PR、push 到 `master` | `npm test` + `npm run build` |
+| **Deploy GitHub Pages** | [`.github/workflows/deploy-pages.yml`](./.github/workflows/deploy-pages.yml) | push 到 `master`，或手动 Run workflow | 测试 → 构建 → 发布 Pages |
+
+合并 PR 到 `master` 会触发对 `master` 的 push，因此 **Deploy 会在合并后自动跑**。也可在 **Actions → Deploy GitHub Pages → Run workflow** 手动重发。
+
+### Pages 设置（本仓库已配置）
+
+1. **Settings → Pages → Source** = **GitHub Actions**  
+   （不要选 “Deploy from a branch” / `gh-pages`，否则 `deploy-pages` 会报 *Deployments are only allowed from gh-pages*）
+2. 自定义域名 `madneal.com`，开启 HTTPS
+3. Workflow 已声明 `pages: write`、`id-token: write`
+
+### 部署后自检
+
+硬刷新 https://madneal.com/subway-shanghai/，页面源码应是 Vite：
+
+```html
+<script type="module" src="/subway-shanghai/assets/index-….js">
+```
+
+而不是旧的 CRA（`/static/js/main.*.chunk.js` / `webpackJsonp`）。
+
+> 本地 `npm run deploy`（推 `gh-pages` 分支）为遗留方式，日常请用 Actions，避免和自动部署不一致。
 
 ## LICENSE
 
-[MIT](https://github.com/neal1991/subway-shanghai/blob/master/LICENSE.md)
-
-
-
-
+[MIT](./LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # :train2::train2::train2: Subway Shanghai
 
-Interactive Shanghai metro map. Originally rebuilt on Create React App; now runs on **Vite + React 18**.
+Interactive Shanghai metro map.
 
-Live site: https://madneal.com/subway-shanghai/
+**Stack:** Vite 6 + React 18  
+**Live:** https://madneal.com/subway-shanghai/  
+**中文说明:** [README-CHINESE.md](./README-CHINESE.md)
+
+Originally a native JS map, later rewritten with Create React App, and now on Vite.
 
 ## Component structure
 
-The whole map is a `Map` component with four child pieces:
+The map is a `Map` with four child pieces:
 
 ![map](https://camo.githubusercontent.com/5491a1b2fcde37cc7dc78ca4890b16316ae5d87d/687474703a2f2f6f7a666f346a6a78622e626b742e636c6f7564646e2e636f6d2f6d61702e706e67)
 
-* **Label** — station and line name text
-* **Station** — normal and transfer stations
-* **Line** — metro line paths
-* **InfoCard** — timesheet, washroom, entrance, and elevator info
+| Component | Role |
+|-----------|------|
+| **Label** | Station and line name text |
+| **Station** | Normal and transfer stations |
+| **Line** | Metro line paths |
+| **InfoCard** | Timesheet, washroom, entrance, and elevator info |
 
 ![subway-react](https://user-images.githubusercontent.com/12164075/37656324-ace5c2b2-2c82-11e8-8b6a-b3c96e091c73.gif)
 
@@ -21,53 +27,66 @@ The whole map is a `Map` component with four child pieces:
 
 ```bash
 npm install
-npm start          # Vite dev server (http://localhost:5173/subway-shanghai/)
+npm start          # http://localhost:5173/subway-shanghai/
 npm run build      # production build → dist/
-npm run preview    # serve the production build locally
-npm run deploy     # optional local deploy via gh-pages branch (prefer Actions)
+npm run preview    # serve dist/ locally
 ```
 
-## Deploy with GitHub Actions
-
-Pushing to `master` runs two workflows:
-
-| Workflow | File | When | What |
-|----------|------|------|------|
-| **CI** | `.github/workflows/ci.yml` | PR + push to `master` | `npm test` + `npm run build` |
-| **Deploy GitHub Pages** | `.github/workflows/deploy-pages.yml` | push to `master` / manual | test → build → publish Pages |
-
-### One-time GitHub settings
-
-1. Open **Settings → Pages**.
-2. Under **Build and deployment → Source**, choose **GitHub Actions** (not “Deploy from a branch”).
-3. If you use a custom domain (`madneal.com`):
-   - Set **Custom domain** to `madneal.com`
-   - Keep DNS pointing at GitHub and enable **Enforce HTTPS**
-4. Under **Settings → Actions → General → Workflow permissions**, allow the default workflow `GITHUB_TOKEN` to deploy Pages (the workflow already sets `pages: write` + `id-token: write`).
-
-### First deploy / redeploy
-
-- Merge to `master`, or open **Actions → Deploy GitHub Pages → Run workflow**.
-- After it is green, open https://madneal.com/subway-shanghai/ and confirm the HTML loads `/subway-shanghai/assets/index-*.js` (Vite), not `/static/js/main.*.chunk.js` (old CRA).
+App base path is `/subway-shanghai/` (project GitHub Pages URL). Local dev uses the same base.
 
 ## Test
 
-Three layers, from fast to full:
-
 | Command | What it covers |
 |---------|----------------|
-| `npm test` | Unit + component tests (Vitest + Testing Library) — timesheet math, data integrity, map click → info card |
-| `npm run test:watch` | Same suite in watch mode while coding |
+| `npm test` | Unit + component tests (Vitest + Testing Library) |
+| `npm run test:watch` | Same suite in watch mode |
 | `npm run test:coverage` | Coverage report under `coverage/` |
-| `npm run test:e2e` | Playwright smoke against the production build (`vite preview`) — load map, open/close station card |
-| `npm run test:all` | Unit tests → production build → e2e |
+| `npm run test:e2e` | Playwright smoke against production build |
+| `npm run test:all` | unit tests → build → e2e |
 
-First-time e2e setup (install browser once):
+First-time e2e browser install:
 
 ```bash
 npx playwright install chromium
 ```
 
+What the suites check:
+
+- **Unit** — timesheet math (weekend last-train extension), pure helpers
+- **Data** — line colors, stations/transfers/labels shape, stationInfo fields
+- **Component** — map renders; click station opens info card; close works
+- **E2E** — real Chromium against `vite preview` build output
+
+## Deploy (GitHub Actions)
+
+Production deploys from **`master`** via GitHub Actions (Pages source = **GitHub Actions**).
+
+| Workflow | File | Triggers | What |
+|----------|------|----------|------|
+| **CI** | [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) | PR + push to `master` | `npm test` + `npm run build` |
+| **Deploy GitHub Pages** | [`.github/workflows/deploy-pages.yml`](./.github/workflows/deploy-pages.yml) | push to `master`, or manual **Run workflow** | test → build → publish Pages |
+
+Merging a PR into `master` creates a push to `master`, so **Deploy** runs automatically after merge. You can also redeploy anytime from **Actions → Deploy GitHub Pages → Run workflow**.
+
+### Pages settings (already applied for this repo)
+
+1. **Settings → Pages → Build and deployment → Source** = **GitHub Actions**  
+   (not “Deploy from a branch” / `gh-pages` — that breaks `actions/deploy-pages`)
+2. Custom domain: `madneal.com`, HTTPS enforced
+3. Workflow permissions include `pages: write` and `id-token: write`
+
+### After a deploy
+
+Hard-refresh https://madneal.com/subway-shanghai/ and confirm the HTML loads Vite assets:
+
+```html
+<script type="module" src="/subway-shanghai/assets/index-….js">
+```
+
+Not the old CRA paths (`/static/js/main.*.chunk.js` / `webpackJsonp`).
+
+> Local `npm run deploy` (gh-pages branch) is legacy; prefer Actions so deploys stay consistent.
+
 ## LICENSE
 
-[MIT](https://github.com/madneal/subway-shanghai/blob/master/LICENSE.md)
+[MIT](./LICENSE.md)


### PR DESCRIPTION
## Summary

Refresh both READMEs to match the current production setup:

- Vite 6 + React 18, live URL on madneal.com
- Develop / test command tables
- GitHub Actions CI + Deploy (merge to master = push trigger)
- Pages must use Source = GitHub Actions (not gh-pages branch)
- Post-deploy check for Vite assets vs old CRA

Also updates `README-CHINESE.md` so EN/中文 stay aligned.